### PR TITLE
Instantiate gist:sequence values for OpinionEnumeration instances

### DIFF
--- a/ontologies/vocabs.ttl
+++ b/ontologies/vocabs.ttl
@@ -1791,6 +1791,7 @@ The creator agrees with the information and believes that it is accurate and cor
 
 This MAY be considered equivalent to a 4 in a numeric scale."""^^xsd:string ;
 	skos:prefLabel "agree"^^xsd:string ;
+	gist:sequence "4"^^xsd:integer ;
 	.
 
 gist:_OpinionEnumeration_disagree
@@ -1802,6 +1803,7 @@ The creator disagrees with the information and believes it is inaccurate or inco
 
 This MAY be considered equivalent to a 2 in a numeric scale."""^^xsd:string ;
 	skos:prefLabel "disagree"^^xsd:string ;
+	gist:sequence "2"^^xsd:integer ;
 	.
 
 gist:_OpinionEnumeration_neutral
@@ -1813,6 +1815,7 @@ The creator is neutral about the accuracy or correctness of the information.
 
 This MAY be considered equivalent to a 3 in a numeric scale."""^^xsd:string ;
 	skos:prefLabel "neutral"^^xsd:string ;
+	gist:sequence "3"^^xsd:integer ;
 	.
 
 gist:_OpinionEnumeration_strongly-agree
@@ -1824,6 +1827,7 @@ The creator strongly agrees with the information and believes that it is accurat
 
 This MAY be considered equivalent to a 5 in a numeric scale."""^^xsd:string ;
 	skos:prefLabel "strongly-agree"^^xsd:string ;
+	gist:sequence "5"^^xsd:integer ;
 	.
 
 gist:_OpinionEnumeration_strongly-disagree
@@ -1835,6 +1839,7 @@ The creator strongly disagrees with the information and believes it is inaccurat
 
 This MAY be considered equivalent to a 1 in a numeric scale."""^^xsd:string ;
 	skos:prefLabel "strongly-disagree"^^xsd:string ;
+	gist:sequence "1"^^xsd:integer ;
 	.
 
 gist:_PatternType_pcre


### PR DESCRIPTION
Closes #41, #77 

Adds the triples for `gist:sequence` as they are attached to the various levels of `gist:OpinionEnumeration` instances.

Will note that there are more enumeration classes and I'll implement the same triple pattern for those as I get to them, so long as they are appropriate and special considerations aren't needed.