### PR TITLE
Issue 47: implement the stix 21 windows integrity level enumeration

### DIFF
--- a/ontologies/vocabs.ttl
+++ b/ontologies/vocabs.ttl
@@ -168,6 +168,21 @@ gist:ThreatActorType
 	rdfs:subClassOf gist:StixCategoryObject ;
 	.
 
+gist:WindowsIntegrityLevel
+	a owl:Class ;
+	rdfs:subClassOf gist:StixCategoryObject ;
+	skos:definition """STIX 2.1 description: 
+The Windows integrity level enumeration is currently used in the following STIX Cyber-observable Object(s):
+●      Process (Windows Process extension)
+
+
+Windows integrity levels are a security feature and represent the trustworthiness of an object."""^^xsd:string ;
+	skos:example ""^^xsd:string ;
+	skos:note "This is described in STIX as an enumeration but no order of the enumeration is given."^^xsd:string ;
+	skos:prefLabel "Windows™ Integrity Level Enumeration"^^xsd:string ;
+	gist:stixTerm "windows-integrity-level-enum"^^xsd:string ;
+	.
+
 gist:_AccountType_facebook
 	a gist:AccountType ;
 	rdfs:label "Facebook"^^xsd:string ;

--- a/ontologies/vocabs.ttl
+++ b/ontologies/vocabs.ttl
@@ -2488,6 +2488,38 @@ There is not enough information available to determine the type of threat actor.
 	skos:prefLabel "unknown"^^xsd:string ;
 	.
 
+gist:_WindowsIntegrityLevel_high
+	a gist:WindowsIntegrityLevel ;
+	skos:definition """STIX 2.1 description: 
+A high level of integrity."""^^xsd:string ;
+	skos:prefLabel "High Integrity Level"^^xsd:string ;
+	gist:stixTerm "high"^^xsd:string ;
+	.
+
+gist:_WindowsIntegrityLevel_low
+	a gist:WindowsIntegrityLevel ;
+	skos:definition """STIX 2.1 description: 
+A low level of integrity."""^^xsd:string ;
+	skos:prefLabel "Low Integrity Level"^^xsd:string ;
+	gist:stixTerm "low"^^xsd:string ;
+	.
+
+gist:_WindowsIntegrityLevel_medium
+	a gist:WindowsIntegrityLevel ;
+	skos:definition """STIX 2.1 description: 
+A medium level of integrity."""^^xsd:string ;
+	skos:prefLabel "Medium Integrity Level"^^xsd:string ;
+	gist:stixTerm "medium"^^xsd:string ;
+	.
+
+gist:_WindowsIntegrityLevel_system
+	a gist:WindowsIntegrityLevel ;
+	skos:definition """STIX 2.1 description: 
+A system level of integrity."""^^xsd:string ;
+	skos:prefLabel "System Integrity Level"^^xsd:string ;
+	gist:stixTerm "system"^^xsd:string ;
+	.
+
 gist:stixTerm
 	a owl:AnnotationProperty ;
 	.


### PR DESCRIPTION
Closes #47 

Looking for feedback/suggestions on what should be used for `gist:sequence` if this is really an enumeration that should use the triple pattern, or if the current set of triples is satisfactory. 

Reference to the STIX 2.1 vocab source: [STIX 2.1 Windows™ Integrity Level Enumeration](https://docs.oasis-open.org/cti/stix/v2.1/csprd01/stix-v2.1-csprd01.html#_Toc16070819)