### PR TITLE
Update rdfs:label to skos:altLabel or skos:prefLabel

### DIFF
--- a/ontologies/gistCyber.ttl
+++ b/ontologies/gistCyber.ttl
@@ -65,7 +65,6 @@ gist:AttackPattern
 		gist:TaskTemplate
 		;
 	rdfs:label "Attack Pattern"^^xsd:string ;
-	rdfs:comment 'Attack Patterns are a type of TTP that describe ways that adversaries attempt to compromise targets. Attack Patterns are used to help categorize attacks, generalize specific attacks to the patterns that they follow, and provide detailed information about how attacks are performed. An example of an attack pattern is "spear phishing": a common type of attack where an attacker sends a carefully crafted e-mail message to a party with the intent of getting them to click a link or open an attachment to deliver malware. Attack Patterns can also be more specific; spear phishing as practiced by a particular threat actor (e.g., they might generally say that the target won a contest) can also be an Attack Pattern. The Attack Pattern SDO contains textual descriptions of the pattern along with references to externally-defined taxonomies of attacks such as CAPEC [CAPEC].'^^xsd:string ;
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
@@ -77,6 +76,7 @@ gist:AttackPattern
 			]
 		) ;
 	] ;
+	skos:definition 'Attack Patterns are a type of TTP that describe ways that adversaries attempt to compromise targets. Attack Patterns are used to help categorize attacks, generalize specific attacks to the patterns that they follow, and provide detailed information about how attacks are performed. An example of an attack pattern is "spear phishing": a common type of attack where an attacker sends a carefully crafted e-mail message to a party with the intent of getting them to click a link or open an attachment to deliver malware. Attack Patterns can also be more specific; spear phishing as practiced by a particular threat actor (e.g., they might generally say that the target won a contest) can also be an Attack Pattern. The Attack Pattern SDO contains textual descriptions of the pattern along with references to externally-defined taxonomies of attacks such as CAPEC [CAPEC].'^^xsd:string ;
 	.
 
 gist:AttackResourceLevel
@@ -91,7 +91,6 @@ gist:Campaign
 		gist:TaskTemplate
 		;
 	rdfs:label "Campaign"^^xsd:string ;
-	rdfs:comment "A Campaign is a grouping of adversarial behaviors that describes a set of malicious activities or attacks (sometimes called waves) that occur over a period of time against a specific set of targets. Campaigns usually have well defined objectives and may be part of an Intrusion Set. Campaigns are often attributed to an intrusion set and threat actors. The threat actors may reuse known infrastructure from the intrusion set or may set up new infrastructure specific for conducting that campaign. Campaigns can be characterized by their objectives and the incidents they cause, people or resources they target, and the resources (infrastructure, intelligence, Malware, Tools, etc.) they use. For example, a Campaign could be used to describe a crime syndicate's attack using a specific variant of malware and new C2 servers against the executives of ACME Bank during the summer of 2016 in order to gain secret information about an upcoming merger with another bank.ey target, and the resources (infrastructure, intelligence, Malware, Tools, etc.) they use."^^xsd:string ;
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
@@ -103,6 +102,7 @@ gist:Campaign
 			]
 		) ;
 	] ;
+	skos:definition "A Campaign is a grouping of adversarial behaviors that describes a set of malicious activities or attacks (sometimes called waves) that occur over a period of time against a specific set of targets. Campaigns usually have well defined objectives and may be part of an Intrusion Set. Campaigns are often attributed to an intrusion set and threat actors. The threat actors may reuse known infrastructure from the intrusion set or may set up new infrastructure specific for conducting that campaign. Campaigns can be characterized by their objectives and the incidents they cause, people or resources they target, and the resources (infrastructure, intelligence, Malware, Tools, etc.) they use. For example, a Campaign could be used to describe a crime syndicate's attack using a specific variant of malware and new C2 servers against the executives of ACME Bank during the summer of 2016 in order to gain secret information about an upcoming merger with another bank.ey target, and the resources (infrastructure, intelligence, Malware, Tools, etc.) they use."^^xsd:string ;
 	.
 
 gist:CategoryObject
@@ -141,7 +141,6 @@ gist:CourseOfAction
 		gist:TaskTemplate
 		;
 	rdfs:label "Course Of Action"^^xsd:string ;
-	rdfs:comment "Note: The Course of Action object in STIX 2.1 is a stub. It is included to support basic use cases (such as sharing prose courses of action) but does not support the ability to represent automated courses of action or contain properties to represent metadata about courses of action. Future STIX 2 releases will expand it to include these capabilities. A Course of Action is an action taken either to prevent an attack or to respond to an attack that is in progress. It may describe technical, automatable responses (applying patches, reconfiguring firewalls) but can also describe higher level actions like employee training or policy changes. For example, a course of action to mitigate a vulnerability could describe applying the patch that fixes it. The Course of Action SDO contains a textual description of the action; a reserved action property also serves as a placeholder for future inclusion of machine automatable courses of action."^^xsd:string ;
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
@@ -153,6 +152,7 @@ gist:CourseOfAction
 			]
 		) ;
 	] ;
+	skos:note "Note: The Course of Action object in STIX 2.1 is a stub. It is included to support basic use cases (such as sharing prose courses of action) but does not support the ability to represent automated courses of action or contain properties to represent metadata about courses of action. Future STIX 2 releases will expand it to include these capabilities. A Course of Action is an action taken either to prevent an attack or to respond to an attack that is in progress. It may describe technical, automatable responses (applying patches, reconfiguring firewalls) but can also describe higher level actions like employee training or policy changes. For example, a course of action to mitigate a vulnerability could describe applying the patch that fixes it. The Course of Action SDO contains a textual description of the action; a reserved action property also serves as a placeholder for future inclusion of machine automatable courses of action."^^xsd:string ;
 	.
 
 gist:CrimeSyndicateThreatActor
@@ -209,7 +209,7 @@ gist:Grouping
 	a owl:Class ;
 	rdfs:subClassOf gist:Collection ;
 	rdfs:label "Grouping"^^xsd:string ;
-	rdfs:comment "STIX Definition: A Grouping object explicitly asserts that the referenced STIX Objects have a shared context, unlike a STIX Bundle (which explicitly conveys no context). A Grouping object should not be confused with an intelligence product, which should be conveyed via a STIX Report. A STIX Grouping object might represent a set of data that, in time, given sufficient analysis, would mature to convey an incident or threat report as a STIX Report object. For example, a Grouping could be used to characterize an ongoing investigation into a security event or incident. A Grouping object could also be used to assert that the referenced STIX Objects are related to an ongoing analysis process, such as when a threat analyst is collaborating with others in their trust community to examine a series of Campaigns and Indicators. The Grouping SDO contains a list of references to SDOs, SCOs, SROs, and SMOs, along with an explicit statement of the context shared by the content, a textual description, and the name of the grouping."^^xsd:string ;
+	skos:definition "STIX Definition: A Grouping object explicitly asserts that the referenced STIX Objects have a shared context, unlike a STIX Bundle (which explicitly conveys no context). A Grouping object should not be confused with an intelligence product, which should be conveyed via a STIX Report. A STIX Grouping object might represent a set of data that, in time, given sufficient analysis, would mature to convey an incident or threat report as a STIX Report object. For example, a Grouping could be used to characterize an ongoing investigation into a security event or incident. A Grouping object could also be used to assert that the referenced STIX Objects are related to an ongoing analysis process, such as when a threat analyst is collaborating with others in their trust community to examine a series of Campaigns and Indicators. The Grouping SDO contains a list of references to SDOs, SCOs, SROs, and SMOs, along with an explicit statement of the context shared by the content, a textual description, and the name of the grouping."^^xsd:string ;
 	.
 
 gist:GroupingContext
@@ -246,7 +246,6 @@ gist:Identity
 	a owl:Class ;
 	rdfs:subClassOf gist:StixDomainObject ;
 	rdfs:label "Identity"^^xsd:string ;
-	rdfs:comment "Identities can represent actual individuals, organizations, or groups (e.g., ACME, Inc.) as well as classes of individuals, organizations, systems or groups (e.g., the finance sector). The Identity SDO can capture basic identifying information, contact information, and the sectors that the Identity belongs to. Identity is used in STIX to represent, among other things, targets of attacks, information sources, object creators, and threat actor identities."^^xsd:string ;
 	owl:equivalentClass
 		[
 			a owl:Class ;
@@ -273,6 +272,7 @@ gist:Identity
 			) ;
 		]
 		;
+	skos:definition "Identities can represent actual individuals, organizations, or groups (e.g., ACME, Inc.) as well as classes of individuals, organizations, systems or groups (e.g., the finance sector). The Identity SDO can capture basic identifying information, contact information, and the sectors that the Identity belongs to. Identity is used in STIX to represent, among other things, targets of attacks, information sources, object creators, and threat actor identities."^^xsd:string ;
 	.
 
 gist:IdentityClass
@@ -289,14 +289,14 @@ gist:Incident
 	a owl:Class ;
 	rdfs:subClassOf gist:Event ;
 	rdfs:label "Incident"^^xsd:string ;
-	rdfs:comment "STIX Definition: Note: The Incident object in STIX 2.1 is a stub. It is included to support basic use cases but does not contain properties to represent metadata about incidents. Future STIX 2 releases will expand it to include these capabilities.  It is suggested that it is used as an extension point for an Incident object defined using the extension facility described in section 7.3."^^xsd:string ;
+	skos:definition "STIX Definition: Note: The Incident object in STIX 2.1 is a stub. It is included to support basic use cases but does not contain properties to represent metadata about incidents. Future STIX 2 releases will expand it to include these capabilities.  It is suggested that it is used as an extension point for an Incident object defined using the extension facility described in section 7.3."^^xsd:string ;
 	.
 
 gist:Indicator
 	a owl:Class ;
 	rdfs:subClassOf gist:ContentExpression ;
 	rdfs:label "Indicator"^^xsd:string ;
-	rdfs:comment "STIX Definition: Indicators contain a pattern that can be used to detect suspicious or malicious cyber activity. For example, an Indicator may be used to represent a set of malicious domains and use the STIX Patterning Language (see section 9) to specify these domains. The Indicator SDO contains a simple textual description, the Kill Chain Phases that it detects behavior in, a time window for when the Indicator is valid or useful, and a required pattern property to capture a structured detection pattern. Conforming STIX implementations MUST support the STIX Patterning Language as defined in section 9. Relationships from the Indicator can describe the malicious or suspicious behavior that it directly detects (Malware, Tool, and Attack Pattern). In addition, it may also imply the presence of a Campaigns, Intrusion Sets, and Threat Actors, etc."^^xsd:string ;
+	skos:definition "STIX Definition: Indicators contain a pattern that can be used to detect suspicious or malicious cyber activity. For example, an Indicator may be used to represent a set of malicious domains and use the STIX Patterning Language (see section 9) to specify these domains. The Indicator SDO contains a simple textual description, the Kill Chain Phases that it detects behavior in, a time window for when the Indicator is valid or useful, and a required pattern property to capture a structured detection pattern. Conforming STIX implementations MUST support the STIX Patterning Language as defined in section 9. Relationships from the Indicator can describe the malicious or suspicious behavior that it directly detects (Malware, Tool, and Attack Pattern). In addition, it may also imply the presence of a Campaigns, Intrusion Sets, and Threat Actors, etc."^^xsd:string ;
 	.
 
 gist:IndicatorType
@@ -367,7 +367,6 @@ gist:IntrusionSet
 		gist:TaskTemplate
 		;
 	rdfs:label "Intrusion Set"^^xsd:string ;
-	rdfs:comment "An Intrusion Set is a grouped set of adversarial behaviors and resources with common properties that is believed to be orchestrated by a single organization. An Intrusion Set may capture multiple Campaigns or other activities that are all tied together by shared attributes indicating a commonly known or unknown Threat Actor. New activity can be attributed to an Intrusion Set even if the Threat Actors behind the attack are not known. Threat Actors can move from supporting one Intrusion Set to supporting another, or they may support multiple Intrusion Sets. Where a Campaign is a set of attacks over a period of time against a specific set of targets to achieve some objective, an Intrusion Set is the entire attack package and may be used over a very long period of time in multiple Campaigns to achieve potentially multiple purposes. While sometimes an Intrusion Set is not active, or changes focus, it is usually difficult to know if it has truly disappeared or ended. Analysts may have varying level of fidelity on attributing an Intrusion Set back to Threat Actors and may be able to only attribute it back to a nation state or perhaps back to an organization within that nation state."^^xsd:string ;
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
@@ -379,13 +378,14 @@ gist:IntrusionSet
 			]
 		) ;
 	] ;
+	skos:definition "An Intrusion Set is a grouped set of adversarial behaviors and resources with common properties that is believed to be orchestrated by a single organization. An Intrusion Set may capture multiple Campaigns or other activities that are all tied together by shared attributes indicating a commonly known or unknown Threat Actor. New activity can be attributed to an Intrusion Set even if the Threat Actors behind the attack are not known. Threat Actors can move from supporting one Intrusion Set to supporting another, or they may support multiple Intrusion Sets. Where a Campaign is a set of attacks over a period of time against a specific set of targets to achieve some objective, an Intrusion Set is the entire attack package and may be used over a very long period of time in multiple Campaigns to achieve potentially multiple purposes. While sometimes an Intrusion Set is not active, or changes focus, it is usually difficult to know if it has truly disappeared or ended. Analysts may have varying level of fidelity on attributing an Intrusion Set back to Threat Actors and may be able to only attribute it back to a nation state or perhaps back to an organization within that nation state."^^xsd:string ;
 	.
 
 gist:Location
 	a owl:Class ;
 	rdfs:subClassOf gist:Place ;
 	rdfs:label "Location"^^xsd:string ;
-	rdfs:comment "STIX Definition: A Location represents a geographic location. The location may be described as any, some or all of the following: region (e.g., North America), civic address (e.g. New York, US), latitude and longitude. \\n\\n Locations are primarily used to give context to other SDOs. For example, a Location could be used in a relationship to describe that the Bourgeois Swallow intrusion set originates from Eastern Europe. \\n\\n The Location SDO can be related to an Identity or Intrusion Set to indicate that the identity or intrusion set is located in that location. It can also be related from a malware or attack pattern to indicate that they target victims in that location. The Location object describes geographic areas, not governments, even in cases where that area might have a government. For example, a Location representing the United States describes the United States as a geographic area, not the federal government of the United States. \\n\\n At least one of the following properties/sets of properties MUST be provided: region, country, latitude and longitude. \\n\\n When a combination of properties is provided (e.g. a region and a latitude and longitude) the more precise properties are what the location describes. In other words, if a location contains both a region of northern-america and a country of us, then the location describes the United States, not all of North America. In cases where a latitude and longitude are specified without a precision, the location describes the most precise other value. \\n\\n If precision is specified, then the datum for latitude and longitude MUST be WGS 84 [WGS84]. Organizations specifying a designated location using latitude and longitude SHOULD specify the precision which is appropriate for the scope of the location being identified. The scope is defined by the boundary as outlined by the precision around the coordinates."^^xsd:string ;
+	skos:definition "STIX Definition: A Location represents a geographic location. The location may be described as any, some or all of the following: region (e.g., North America), civic address (e.g. New York, US), latitude and longitude. \\n\\n Locations are primarily used to give context to other SDOs. For example, a Location could be used in a relationship to describe that the Bourgeois Swallow intrusion set originates from Eastern Europe. \\n\\n The Location SDO can be related to an Identity or Intrusion Set to indicate that the identity or intrusion set is located in that location. It can also be related from a malware or attack pattern to indicate that they target victims in that location. The Location object describes geographic areas, not governments, even in cases where that area might have a government. For example, a Location representing the United States describes the United States as a geographic area, not the federal government of the United States. \\n\\n At least one of the following properties/sets of properties MUST be provided: region, country, latitude and longitude. \\n\\n When a combination of properties is provided (e.g. a region and a latitude and longitude) the more precise properties are what the location describes. In other words, if a location contains both a region of northern-america and a country of us, then the location describes the United States, not all of North America. In cases where a latitude and longitude are specified without a precision, the location describes the most precise other value. \\n\\n If precision is specified, then the datum for latitude and longitude MUST be WGS 84 [WGS84]. Organizations specifying a designated location using latitude and longitude SHOULD specify the precision which is appropriate for the scope of the location being identified. The scope is defined by the boundary as outlined by the precision around the coordinates."^^xsd:string ;
 	.
 
 gist:Malware
@@ -395,7 +395,6 @@ gist:Malware
 		gist:StixDomainObject
 		;
 	rdfs:label "Malware"^^xsd:string ;
-	rdfs:comment "STIX Definition: Malware is a type of TTP that represents malicious code. It generally refers to a program that is inserted into a system, usually covertly. The intent is to compromise the confidentiality, integrity, or availability of the victim's data, applications, or operating system (OS) or otherwise annoy or disrupt the victim. The Malware SDO characterizes, identifies, and categorizes malware instances and families from data that may be derived from analysis. This SDO captures detailed information about how the malware works and what it does. This SDO captures contextual data relevant to sharing Malware data without requiring the full analysis provided by the Malware Analysis SDO. The Indicator SDO provides intelligence producers with the ability to define, using the STIX Pattern Grammar in a standard way to identify and detect behaviors associated with malicious activities. Although the Malware SDO provides vital intelligence on a specific instance or malware family, it does not provide a standard grammar that the Indicator SDO provides to identify those properties in security detection systems designed to process the STIX Pattern grammar. We strongly encourage the use of STIX Indicators for the detection of actual malware, due to its use of the STIX Patterning language and the clear semantics that it provides. To minimize the risk of a consumer compromising their system in parsing malware samples, producers SHOULD consider sharing defanged content (archive and password-protected samples) instead of raw, base64-encoded malware samples."^^xsd:string ;
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
@@ -407,6 +406,7 @@ gist:Malware
 			]
 		) ;
 	] ;
+	skos:definition "STIX Definition: Malware is a type of TTP that represents malicious code. It generally refers to a program that is inserted into a system, usually covertly. The intent is to compromise the confidentiality, integrity, or availability of the victim's data, applications, or operating system (OS) or otherwise annoy or disrupt the victim. The Malware SDO characterizes, identifies, and categorizes malware instances and families from data that may be derived from analysis. This SDO captures detailed information about how the malware works and what it does. This SDO captures contextual data relevant to sharing Malware data without requiring the full analysis provided by the Malware Analysis SDO. The Indicator SDO provides intelligence producers with the ability to define, using the STIX Pattern Grammar in a standard way to identify and detect behaviors associated with malicious activities. Although the Malware SDO provides vital intelligence on a specific instance or malware family, it does not provide a standard grammar that the Indicator SDO provides to identify those properties in security detection systems designed to process the STIX Pattern grammar. We strongly encourage the use of STIX Indicators for the detection of actual malware, due to its use of the STIX Patterning language and the clear semantics that it provides. To minimize the risk of a consumer compromising their system in parsing malware samples, producers SHOULD consider sharing defanged content (archive and password-protected samples) instead of raw, base64-encoded malware samples."^^xsd:string ;
 	.
 
 gist:MalwareAnalysis
@@ -487,7 +487,7 @@ gist:SoftwareVulnerability
 	a owl:Class ;
 	rdfs:subClassOf gist:Defect ;
 	rdfs:label "Software Vulnerability"^^xsd:string ;
-	rdfs:comment "A Vulnerability is a weakness or defect in the requirements, designs, or implementations of the computational logic (e.g., code) found in software and some hardware components (e.g., firmware) that can be directly exploited to negatively impact the confidentiality, integrity, or availability of that system. \\n\\nCVE is a list of information security vulnerabilities and exposures that provides common names for publicly known problems [CVE]. For example, if a piece of malware exploits CVE-2015-12345, a Malware object could be linked to a Vulnerability object that references CVE-2015-12345. \\n\\nThe Vulnerability SDO is primarily used to link to external definitions of vulnerabilities or to describe 0-day vulnerabilities that do not yet have an external definition. Typically, other SDOs assert relationships to Vulnerability objects when a specific vulnerability is targeted and exploited as part of malicious cyber activity. As such, Vulnerability objects can be used as a linkage to the asset management and compliance process."^^xsd:string ;
+	skos:definition "A Vulnerability is a weakness or defect in the requirements, designs, or implementations of the computational logic (e.g., code) found in software and some hardware components (e.g., firmware) that can be directly exploited to negatively impact the confidentiality, integrity, or availability of that system. \\n\\nCVE is a list of information security vulnerabilities and exposures that provides common names for publicly known problems [CVE]. For example, if a piece of malware exploits CVE-2015-12345, a Malware object could be linked to a Vulnerability object that references CVE-2015-12345. \\n\\nThe Vulnerability SDO is primarily used to link to external definitions of vulnerabilities or to describe 0-day vulnerabilities that do not yet have an external definition. Typically, other SDOs assert relationships to Vulnerability objects when a specific vulnerability is targeted and exploited as part of malicious cyber activity. As such, Vulnerability objects can be used as a linkage to the asset management and compliance process."^^xsd:string ;
 	.
 
 gist:SpyThreatActor
@@ -586,7 +586,6 @@ gist:ThreatActor
 		gist:StixDomainObject
 		;
 	rdfs:label "Threat Actor"^^xsd:string ;
-	rdfs:comment "Threat Actors are actual individuals, groups, or organizations believed to be operating with malicious intent. A Threat Actor is not an Intrusion Set but may support or be affiliated with various Intrusion Sets, groups, or organizations over time. \\n\\nThreat Actors leverage their resources, and possibly the resources of an Intrusion Set, to conduct attacks and run Campaigns against targets. \\n\\nThreat Actors can be characterized by their motives, capabilities, goals, sophistication level, past activities, resources they have access to, and their role in the organization."^^xsd:string ;
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
@@ -598,6 +597,7 @@ gist:ThreatActor
 			]
 		) ;
 	] ;
+	skos:definition "Threat Actors are actual individuals, groups, or organizations believed to be operating with malicious intent. A Threat Actor is not an Intrusion Set but may support or be affiliated with various Intrusion Sets, groups, or organizations over time. \\n\\nThreat Actors leverage their resources, and possibly the resources of an Intrusion Set, to conduct attacks and run Campaigns against targets. \\n\\nThreat Actors can be characterized by their motives, capabilities, goals, sophistication level, past activities, resources they have access to, and their role in the organization."^^xsd:string ;
 	.
 
 gist:ThreatActorRole
@@ -625,7 +625,6 @@ gist:Tool
 		gist:StixDomainObject
 		;
 	rdfs:label "Tool"^^xsd:string ;
-	rdfs:comment "STIX Definition:Tools are legitimate software that can be used by threat actors to perform attacks. Knowing how and when threat actors use such tools can be important for understanding how campaigns are executed. Unlike malware, these tools or software packages are often found on a system and have legitimate purposes for power users, system administrators, network administrators, or even normal users. Remote access tools (e.g., RDP) and network scanning tools (e.g., Nmap) are examples of Tools that may be used by a Threat Actor during an attack. \\n\\nThe Tool SDO characterizes the properties of these software tools and can be used as a basis for making an assertion about how a Threat Actor uses them during an attack. It contains properties to name and describe the tool, a list of Kill Chain Phases the tool can be used to carry out, and the version of the tool. \\n\\nThis SDO MUST NOT be used to characterize malware. Further, Tool MUST NOT be used to characterize tools used as part of a course of action in response to an attack."^^xsd:string ;
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
@@ -637,6 +636,7 @@ gist:Tool
 			]
 		) ;
 	] ;
+	skos:definition "STIX Definition:Tools are legitimate software that can be used by threat actors to perform attacks. Knowing how and when threat actors use such tools can be important for understanding how campaigns are executed. Unlike malware, these tools or software packages are often found on a system and have legitimate purposes for power users, system administrators, network administrators, or even normal users. Remote access tools (e.g., RDP) and network scanning tools (e.g., Nmap) are examples of Tools that may be used by a Threat Actor during an attack. \\n\\nThe Tool SDO characterizes the properties of these software tools and can be used as a basis for making an assertion about how a Threat Actor uses them during an attack. It contains properties to name and describe the tool, a list of Kill Chain Phases the tool can be used to carry out, and the version of the tool. \\n\\nThis SDO MUST NOT be used to characterize malware. Further, Tool MUST NOT be used to characterize tools used as part of a course of action in response to an attack."^^xsd:string ;
 	.
 
 gist:UnknownThreatActor

--- a/ontologies/vocabs.ttl
+++ b/ontologies/vocabs.ttl
@@ -10,9 +10,11 @@
 
 <https://w3id.org/semanticarts/ontology/vocabulary>
 	a owl:Ontology ;
-	rdfs:comment 'Some STIX properties are defined using open vocabularies or enumerations. Enumerations and open vocabularies are defined in STIX in order to enhance interoperability by increasing the likelihood that different entities use the same exact string to represent the same concept. If used consistently, open vocabularies make it less likely that one entity refers to the energy sector as "Energy" and another as "Energy Sector", thereby making comparison and correlation easier. \\n\\n While using predefined values from STIX vocabularies is strongly encouraged, in some cases this may not be feasible. To address this, producers are permitted to use values outside of the open vocabulary. In the case of enumerations, producers are required to use only the values defined within the STIX specification. \\n\\n STIX open vocabularies and enumerations are defined in section 10. Properties that are defined as open vocabularies identify a suggested vocabulary from that section. For example, the Threat Actor sophistication property, as defined in section 4.17, uses the Threat Actor Sophistication vocabulary as defined in section 10.25.'@en-US ;
 	owl:versionInfo "2.1.0"^^xsd:string ;
-	skos:definition "Category Instances for STIX Vocabularies and Enumerations"^^xsd:string ;
+	skos:definition
+		"Category Instances for STIX Vocabularies and Enumerations"^^xsd:string ,
+		'Some STIX properties are defined using open vocabularies or enumerations. Enumerations and open vocabularies are defined in STIX in order to enhance interoperability by increasing the likelihood that different entities use the same exact string to represent the same concept. If used consistently, open vocabularies make it less likely that one entity refers to the energy sector as "Energy" and another as "Energy Sector", thereby making comparison and correlation easier. \\n\\n While using predefined values from STIX vocabularies is strongly encouraged, in some cases this may not be feasible. To address this, producers are permitted to use values outside of the open vocabulary. In the case of enumerations, producers are required to use only the values defined within the STIX specification. \\n\\n STIX open vocabularies and enumerations are defined in section 10. Properties that are defined as open vocabularies identify a suggested vocabulary from that section. For example, the Threat Actor sophistication property, as defined in section 4.17, uses the Threat Actor Sophistication vocabulary as defined in section 10.25.'@en-US
+		;
 	skos:prefLabel "Category Instances for STIX Vocabularies and Enumerations"^^xsd:string ;
 	.
 

--- a/ontologies/vocabs.ttl
+++ b/ontologies/vocabs.ttl
@@ -12,6 +12,7 @@
 	a owl:Ontology ;
 	rdfs:comment 'Some STIX properties are defined using open vocabularies or enumerations. Enumerations and open vocabularies are defined in STIX in order to enhance interoperability by increasing the likelihood that different entities use the same exact string to represent the same concept. If used consistently, open vocabularies make it less likely that one entity refers to the energy sector as "Energy" and another as "Energy Sector", thereby making comparison and correlation easier. \\n\\n While using predefined values from STIX vocabularies is strongly encouraged, in some cases this may not be feasible. To address this, producers are permitted to use values outside of the open vocabulary. In the case of enumerations, producers are required to use only the values defined within the STIX specification. \\n\\n STIX open vocabularies and enumerations are defined in section 10. Properties that are defined as open vocabularies identify a suggested vocabulary from that section. For example, the Threat Actor sophistication property, as defined in section 4.17, uses the Threat Actor Sophistication vocabulary as defined in section 10.25.'@en-US ;
 	owl:versionInfo "2.1.0"^^xsd:string ;
+	skos:definition "Category Instances for STIX Vocabularies and Enumerations"^^xsd:string ;
 	skos:prefLabel "Category Instances for STIX Vocabularies and Enumerations"^^xsd:string ;
 	.
 

--- a/ontologies/vocabs.ttl
+++ b/ontologies/vocabs.ttl
@@ -10,9 +10,9 @@
 
 <https://w3id.org/semanticarts/ontology/vocabulary>
 	a owl:Ontology ;
-	rdfs:label "Category Instances for STIX Vocabularies and Enumerations"^^xsd:string ;
 	rdfs:comment 'Some STIX properties are defined using open vocabularies or enumerations. Enumerations and open vocabularies are defined in STIX in order to enhance interoperability by increasing the likelihood that different entities use the same exact string to represent the same concept. If used consistently, open vocabularies make it less likely that one entity refers to the energy sector as "Energy" and another as "Energy Sector", thereby making comparison and correlation easier. \\n\\n While using predefined values from STIX vocabularies is strongly encouraged, in some cases this may not be feasible. To address this, producers are permitted to use values outside of the open vocabulary. In the case of enumerations, producers are required to use only the values defined within the STIX specification. \\n\\n STIX open vocabularies and enumerations are defined in section 10. Properties that are defined as open vocabularies identify a suggested vocabulary from that section. For example, the Threat Actor sophistication property, as defined in section 4.17, uses the Threat Actor Sophistication vocabulary as defined in section 10.25.'@en-US ;
 	owl:versionInfo "2.1.0"^^xsd:string ;
+	skos:prefLabel "Category Instances for STIX Vocabularies and Enumerations"^^xsd:string ;
 	.
 
 skos:definition
@@ -250,7 +250,6 @@ An enumeration of Windows service statuses."""^^xsd:string ;
 
 gist:_AccountType_facebook
 	a gist:AccountType ;
-	rdfs:label "Facebook"^^xsd:string ;
 	skos:altLabel "Facebook"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Specifies a Facebook account"""^^xsd:string ;
@@ -260,7 +259,6 @@ Specifies a Facebook account"""^^xsd:string ;
 
 gist:_AccountType_ldap
 	a gist:AccountType ;
-	rdfs:label "LDAP"^^xsd:string ;
 	skos:altLabel "LDAP"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Specifies an LDAP account"""^^xsd:string ;
@@ -270,7 +268,6 @@ Specifies an LDAP account"""^^xsd:string ;
 
 gist:_AccountType_nis
 	a gist:AccountType ;
-	rdfs:label "NIS"^^xsd:string ;
 	skos:altLabel "NIS"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Specifies an NIS account"""^^xsd:string ;
@@ -280,7 +277,6 @@ Specifies an NIS account"""^^xsd:string ;
 
 gist:_AccountType_openid
 	a gist:AccountType ;
-	rdfs:label "OpenID"^^xsd:string ;
 	skos:altLabel "OpenID"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Specifies an OpenID account"""^^xsd:string ;
@@ -290,7 +286,6 @@ Specifies an OpenID account"""^^xsd:string ;
 
 gist:_AccountType_radius
 	a gist:AccountType ;
-	rdfs:label "Radius"^^xsd:string ;
 	skos:altLabel "Radius"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Specifies a RADIUS account"""^^xsd:string ;
@@ -300,7 +295,6 @@ Specifies a RADIUS account"""^^xsd:string ;
 
 gist:_AccountType_skype
 	a gist:AccountType ;
-	rdfs:label "Skype"^^xsd:string ;
 	skos:altLabel "Skype"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Specifies a Skype account"""^^xsd:string ;
@@ -310,7 +304,6 @@ Specifies a Skype account"""^^xsd:string ;
 
 gist:_AccountType_tacacs
 	a gist:AccountType ;
-	rdfs:label "TACACS"^^xsd:string ;
 	skos:altLabel "TACACS"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Specifies a TACACS account"""^^xsd:string ;
@@ -320,7 +313,6 @@ Specifies a TACACS account"""^^xsd:string ;
 
 gist:_AccountType_twitter
 	a gist:AccountType ;
-	rdfs:label "Twitter"^^xsd:string ;
 	skos:altLabel "Twitter"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Specifies a Twitter account"""^^xsd:string ;
@@ -330,7 +322,6 @@ Specifies a Twitter account"""^^xsd:string ;
 
 gist:_AccountType_unix
 	a gist:AccountType ;
-	rdfs:label "UNIX"^^xsd:string ;
 	skos:altLabel "Unix"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Specifies a POSIX account"""^^xsd:string ;
@@ -340,8 +331,10 @@ Specifies a POSIX account"""^^xsd:string ;
 
 gist:_AccountType_windows-domain
 	a gist:AccountType ;
-	rdfs:label "Windows Domain"^^xsd:string ;
-	skos:altLabel "Windows-Domain"^^xsd:string ;
+	skos:altLabel
+		"Windows Domain"^^xsd:string ,
+		"Windows-Domain"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 Specifies a Windows Domain account"""^^xsd:string ;
 	skos:prefLabel "windows-domain"^^xsd:string ;
@@ -350,8 +343,10 @@ Specifies a Windows Domain account"""^^xsd:string ;
 
 gist:_AccountType_windows_local
 	a gist:AccountType ;
-	rdfs:label "Windows Local"^^xsd:string ;
-	skos:altLabel "Windows-Local"^^xsd:string ;
+	skos:altLabel
+		"Windows Local"^^xsd:string ,
+		"Windows-Local"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 Specifies a Windows Local account"""^^xsd:string ;
 	skos:prefLabel "windows-local"^^xsd:string ;
@@ -360,7 +355,6 @@ Specifies a Windows Local account"""^^xsd:string ;
 
 gist:_AttackMotivation_accidental
 	a gist:AttackMotivation ;
-	rdfs:label "Accidental"^^xsd:string ;
 	skos:altLabel "Accidental"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 A non-hostile actor whose benevolent or harmless intent inadvertently causes harm.
@@ -374,7 +368,6 @@ For example, a well-meaning and dedicated employee who through distraction or po
 
 gist:_AttackMotivation_coercion
 	a gist:AttackMotivation ;
-	rdfs:label "Coercion"^^xsd:string ;
 	skos:altLabel "Coercion"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Being forced to act on someone else's behalf.
@@ -388,7 +381,6 @@ Adversaries who are motivated by coercion are often forced through intimidation 
 
 gist:_AttackMotivation_dominance
 	a gist:AttackMotivation ;
-	rdfs:label "Dominance"^^xsd:string ;
 	skos:altLabel "Dominance"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 A desire to assert superiority over someone or something else.
@@ -402,7 +394,6 @@ Adversaries who are seeking dominance over a target are focused on using their p
 
 gist:_AttackMotivation_ideology
 	a gist:AttackMotivation ;
-	rdfs:label "Ideology"^^xsd:string ;
 	skos:altLabel "Ideology"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 A passion to express a set of ideas, beliefs, and values that may shape and drive harmful and illegal acts.
@@ -420,7 +411,6 @@ For example, an activist group may sabotage a company’s equipment because they
 
 gist:_AttackMotivation_notoriety
 	a gist:AttackMotivation ;
-	rdfs:label "Notoriety"^^xsd:string ;
 	skos:altLabel "Notoriety"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Seeking prestige or to become well known through some activity.
@@ -434,8 +424,10 @@ Adversaries motivated by notoriety are often seeking either personal validation 
 
 gist:_AttackMotivation_organizational-gain
 	a gist:AttackMotivation ;
-	rdfs:label "Oranizational Gain"^^xsd:string ;
-	skos:altLabel "Oranizational-Gain"^^xsd:string ;
+	skos:altLabel
+		"Oranizational Gain"^^xsd:string ,
+		"Oranizational-Gain"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 Seeking advantage over a competing organization, including a military organization.
 
@@ -448,8 +440,10 @@ Adversaries motivated by increased profit or other gains through an unfairly obt
 
 gist:_AttackMotivation_personal-gain
 	a gist:AttackMotivation ;
-	rdfs:label "Personal Gain"^^xsd:string ;
-	skos:altLabel "Personal-Gain"^^xsd:string ;
+	skos:altLabel
+		"Personal Gain"^^xsd:string ,
+		"Personal-Gain"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 The desire to improve one’s own financial status.
 
@@ -466,8 +460,10 @@ While a Threat Actor or Intrusion Set may be seeking personal gain, this does no
 
 gist:_AttackMotivation_personal-satisfaction
 	a gist:AttackMotivation ;
-	rdfs:label "Personal Satisfaction"^^xsd:string ;
-	skos:altLabel "Personal-Satisfaction"^^xsd:string ;
+	skos:altLabel
+		"Personal Satisfaction"^^xsd:string ,
+		"Personal-Satisfaction"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 A desire to satisfy a strictly personal goal, including curiosity, thrill-seeking, amusement, etc.
 
@@ -480,7 +476,6 @@ Threat Actors or Intrusion Set driven by personal satisfaction may incidentally 
 
 gist:_AttackMotivation_revenge
 	a gist:AttackMotivation ;
-	rdfs:label "Revenge"^^xsd:string ;
 	skos:altLabel "Revenge"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 A desire to avenge perceived wrongs through harmful actions such as sabotage, violence, theft, fraud, or embarrassing certain individuals or the organization.
@@ -494,7 +489,6 @@ A disgruntled Threat Actor or Intrusion Set seeking revenge can include current 
 
 gist:_AttackMotivation_unpredictable
 	a gist:AttackMotivation ;
-	rdfs:label "Unpredictable"^^xsd:string ;
 	skos:altLabel "Unpredictable"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Acting without identifiable reason or purpose and creating unpredictable events.
@@ -508,7 +502,6 @@ Unpredictable is not a miscellaneous or default category. Unpredictable means a 
 
 gist:_AttackResourceLevel_club
 	a gist:AttackResourceLevel ;
-	rdfs:label "Club"^^xsd:string ;
 	skos:altLabel "Club"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Members interact on a social and volunteer basis, often with little personal interest in the specific target. An example might be a core group of unrelated activists who regularly exchange tips on a particular blog. Group persists long term."""^^xsd:string ;
@@ -518,7 +511,6 @@ Members interact on a social and volunteer basis, often with little personal int
 
 gist:_AttackResourceLevel_contest
 	a gist:AttackResourceLevel ;
-	rdfs:label "Contest"^^xsd:string ;
 	skos:altLabel "Contest"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 A short-lived and perhaps anonymous interaction that concludes when the participants have achieved a single goal. For example, people who break into systems just for thrills or prestige may hold a contest to see who can break into a specific target first. It also includes announced \"operations\" to achieve a specific goal, such as the original \"OpIsrael\" call for volunteers to disrupt all of Israel's Internet functions for a day."""^^xsd:string ;
@@ -528,7 +520,6 @@ A short-lived and perhaps anonymous interaction that concludes when the particip
 
 gist:_AttackResourceLevel_government
 	a gist:AttackResourceLevel ;
-	rdfs:label "Government"^^xsd:string ;
 	skos:altLabel "Government"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Controls public assets and functions within a jurisdiction; very well resourced and persists long term."""^^xsd:string ;
@@ -538,7 +529,6 @@ Controls public assets and functions within a jurisdiction; very well resourced 
 
 gist:_AttackResourceLevel_individual
 	a gist:AttackResourceLevel ;
-	rdfs:label "Individual"^^xsd:string ;
 	skos:altLabel "Individual"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Resources limited to the average individual; Threat Actor acts independently."""^^xsd:string ;
@@ -548,7 +538,6 @@ Resources limited to the average individual; Threat Actor acts independently."""
 
 gist:_AttackResourceLevel_organization
 	a gist:AttackResourceLevel ;
-	rdfs:label "Organization"^^xsd:string ;
 	skos:altLabel "Organization"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Larger and better resourced than a team; typically, a company or crime syndicate. Usually operates in multiple geographic areas and persists long term."""^^xsd:string ;
@@ -558,7 +547,6 @@ Larger and better resourced than a team; typically, a company or crime syndicate
 
 gist:_AttackResourceLevel_team
 	a gist:AttackResourceLevel ;
-	rdfs:label "Team"^^xsd:string ;
 	skos:altLabel "Team"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 A formally organized group with a leader, typically motivated by a specific goal and organized around that goal. Group persists long term and typically operates within a single geography."""^^xsd:string ;
@@ -568,7 +556,6 @@ A formally organized group with a leader, typically motivated by a specific goal
 
 gist:_EncryptionAlgorithm_AES_256_GCM
 	a gist:EncryptionAlgorithm ;
-	rdfs:label "AES-256-GCM"^^xsd:string ;
 	skos:altLabel "AES-256-GCM"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Specifies the AES-256-GCM cipher, as defined in [NIST SP800-38D]"""^^xsd:string ;
@@ -578,7 +565,6 @@ Specifies the AES-256-GCM cipher, as defined in [NIST SP800-38D]"""^^xsd:string 
 
 gist:_EncryptionAlgorithm_ChaCha20-Poly1305
 	a gist:EncryptionAlgorithm ;
-	rdfs:label "ChaCha20-Poly1305"^^xsd:string ;
 	skos:altLabel "ChaCha20-Poly1305"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Specifies the ChaCha20-Poly1305 stream cipher, as defined in [RFC7539]."""^^xsd:string ;
@@ -588,8 +574,10 @@ Specifies the ChaCha20-Poly1305 stream cipher, as defined in [RFC7539]."""^^xsd:
 
 gist:_EncryptionAlgorithm_mime-type-indicated
 	a gist:EncryptionAlgorithm ;
-	rdfs:label "Mime Type Indicated"^^xsd:string ;
-	skos:altLabel "Mime-Type-Indicated"^^xsd:string ;
+	skos:altLabel
+		"Mime Type Indicated"^^xsd:string ,
+		"Mime-Type-Indicated"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 The encryption algorithm is self-defined by the artifact's data. The specified mime-type tells you which format it is, e.g., Word Doc or GPG. This is intended for formats like Zip files and Word files which take a simple password, or GPG armored files that contain the key blob along with the file."""^^xsd:string ;
 	skos:prefLabel "mime-type-indicated"^^xsd:string ;
@@ -998,7 +986,6 @@ There is not enough information available to determine the type of indicator."""
 
 gist:_IndustrySector_aerospace
 	a gist:IndustrySector ;
-	rdfs:label "Aerospace"^^xsd:string ;
 	skos:altLabel "Aerospace"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Aerospace industry sector"""^^xsd:string ;
@@ -1008,7 +995,6 @@ Tag for the Aerospace industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_agriculture
 	a gist:IndustrySector ;
-	rdfs:label "Agriculture"^^xsd:string ;
 	skos:altLabel "Agriculture"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Agriculture industry sector"""^^xsd:string ;
@@ -1018,7 +1004,6 @@ Tag for the Agriculture industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_automotive
 	a gist:IndustrySector ;
-	rdfs:label "Automotive"^^xsd:string ;
 	skos:altLabel "Automotive"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Automotive industry sector"""^^xsd:string ;
@@ -1028,7 +1013,6 @@ Tag for the Automotive industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_chemical
 	a gist:IndustrySector ;
-	rdfs:label "Chemical"^^xsd:string ;
 	skos:altLabel "Chemical"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Chemical industry sector"""^^xsd:string ;
@@ -1038,7 +1022,6 @@ Tag for the Chemical industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_commercial
 	a gist:IndustrySector ;
-	rdfs:label "Commercial"^^xsd:string ;
 	skos:altLabel "Commercial"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Commercial industry sector"""^^xsd:string ;
@@ -1048,7 +1031,6 @@ Tag for the Commercial industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_communications
 	a gist:IndustrySector ;
-	rdfs:label "Communications"^^xsd:string ;
 	skos:altLabel "Communications"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Communications industry sector"""^^xsd:string ;
@@ -1058,7 +1040,6 @@ Tag for the Communications industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_construction
 	a gist:IndustrySector ;
-	rdfs:label "Construction"^^xsd:string ;
 	skos:altLabel "Construction"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Construction industry sector"""^^xsd:string ;
@@ -1068,7 +1049,6 @@ Tag for the Construction industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_defense
 	a gist:IndustrySector ;
-	rdfs:label "Defense"^^xsd:string ;
 	skos:altLabel "Defense"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Defense industry sector"""^^xsd:string ;
@@ -1078,7 +1058,6 @@ Tag for the Defense industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_education
 	a gist:IndustrySector ;
-	rdfs:label "Education"^^xsd:string ;
 	skos:altLabel "Education"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Education industry sector"""^^xsd:string ;
@@ -1088,8 +1067,10 @@ Tag for the Education industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_emergency-services
 	a gist:IndustrySector ;
-	rdfs:label "Emergency-Services"^^xsd:string ;
-	skos:altLabel "Emergency-Services"^^xsd:string ;
+	skos:altLabel
+		"Emergency Services"^^xsd:string ,
+		"Emergency-Services"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 Tag for the emergency services industry sector"""^^xsd:string ;
 	skos:prefLabel "emergency-services"^^xsd:string ;
@@ -1098,7 +1079,6 @@ Tag for the emergency services industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_energy
 	a gist:IndustrySector ;
-	rdfs:label "Energy"^^xsd:string ;
 	skos:altLabel "Energy"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Energy industry sector"""^^xsd:string ;
@@ -1108,7 +1088,6 @@ Tag for the Energy industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_entertainment
 	a gist:IndustrySector ;
-	rdfs:label "Entertainment"^^xsd:string ;
 	skos:altLabel "Entertainment"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Entertainment industry sector"""^^xsd:string ;
@@ -1118,8 +1097,10 @@ Tag for the Entertainment industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_financial-services
 	a gist:IndustrySector ;
-	rdfs:label "Financial Services"^^xsd:string ;
-	skos:altLabel "Financial-Services"^^xsd:string ;
+	skos:altLabel
+		"Financial Services"^^xsd:string ,
+		"Financial-Services"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 Tag for the Financial-Services industry sector"""^^xsd:string ;
 	skos:prefLabel "financial-services"^^xsd:string ;
@@ -1128,7 +1109,6 @@ Tag for the Financial-Services industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_government
 	a gist:IndustrySector ;
-	rdfs:label "Government"^^xsd:string ;
 	skos:altLabel "Government"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Government industry sector"""^^xsd:string ;
@@ -1138,8 +1118,10 @@ Tag for the Government industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_government-Local
 	a gist:IndustrySector ;
-	rdfs:label "Government Local"^^xsd:string ;
-	skos:altLabel "Government-Local"^^xsd:string ;
+	skos:altLabel
+		"Government Local"^^xsd:string ,
+		"Government-Local"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 Tag for the government local industry sector"""^^xsd:string ;
 	skos:prefLabel "government-local"^^xsd:string ;
@@ -1148,8 +1130,10 @@ Tag for the government local industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_government-National
 	a gist:IndustrySector ;
-	rdfs:label "Government National"^^xsd:string ;
-	skos:altLabel "Government-National"^^xsd:string ;
+	skos:altLabel
+		"Government National"^^xsd:string ,
+		"Government-National"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 Tag for the government-national industry sector"""^^xsd:string ;
 	skos:prefLabel "government-national"^^xsd:string ;
@@ -1158,8 +1142,10 @@ Tag for the government-national industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_government-Public-Services
 	a gist:IndustrySector ;
-	rdfs:label "Government Public Services"^^xsd:string ;
-	skos:altLabel "Government-Public-Services"^^xsd:string ;
+	skos:altLabel
+		"Government Public Services"^^xsd:string ,
+		"Government-Public-Services"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 Tag for the government public services industry sector"""^^xsd:string ;
 	skos:prefLabel "government-public-services"^^xsd:string ;
@@ -1168,8 +1154,10 @@ Tag for the government public services industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_government-Regional
 	a gist:IndustrySector ;
-	rdfs:label "Government Regional"^^xsd:string ;
-	skos:altLabel "Government-Regional"^^xsd:string ;
+	skos:altLabel
+		"Government Regional"^^xsd:string ,
+		"Government-Regional"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 Tag for the government regional industry sector"""^^xsd:string ;
 	skos:prefLabel "government-regional"^^xsd:string ;
@@ -1178,7 +1166,6 @@ Tag for the government regional industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_healthcare
 	a gist:IndustrySector ;
-	rdfs:label "Healthcare"^^xsd:string ;
 	skos:altLabel "Healthcare"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the healthcare industry sector"""^^xsd:string ;
@@ -1188,8 +1175,10 @@ Tag for the healthcare industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_hospitality-Leisure
 	a gist:IndustrySector ;
-	rdfs:label "Hospitality Leisure"^^xsd:string ;
-	skos:altLabel "Hospitality-Leisure"^^xsd:string ;
+	skos:altLabel
+		"Hospitality Leisure"^^xsd:string ,
+		"Hospitality-Leisure"^^xsd:string
+		;
 	skos:definition """STIX 2.1 description:
 Tag for the hospitality leisure industry sector"""^^xsd:string ;
 	skos:prefLabel "hospitality-leisure"^^xsd:string ;
@@ -1198,7 +1187,6 @@ Tag for the hospitality leisure industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_infrastructure
 	a gist:IndustrySector ;
-	rdfs:label "Infrastructure"^^xsd:string ;
 	skos:altLabel "Infrastructure"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the infrastructure industry sector"""^^xsd:string ;
@@ -1208,7 +1196,6 @@ Tag for the infrastructure industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_infrastructure-Dams
 	a gist:IndustrySector ;
-	rdfs:label "Dams"^^xsd:string ;
 	skos:altLabel "Dams"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Infrastructure-Dams industry sector"""^^xsd:string ;
@@ -1218,7 +1205,6 @@ Tag for the Infrastructure-Dams industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_infrastructure-Nuclear
 	a gist:IndustrySector ;
-	rdfs:label "Nuclear"^^xsd:string ;
 	skos:altLabel "Nuclear"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Nuclear industry sector"""^^xsd:string ;
@@ -1228,7 +1214,6 @@ Tag for the Nuclear industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_infrastructure-Water
 	a gist:IndustrySector ;
-	rdfs:label "Water"^^xsd:string ;
 	skos:altLabel "Water"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Water industry sector"""^^xsd:string ;
@@ -1238,7 +1223,6 @@ Tag for the Water industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_insurance
 	a gist:IndustrySector ;
-	rdfs:label "Insurance"^^xsd:string ;
 	skos:altLabel "Insurance"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Insurance industry sector"""^^xsd:string ;
@@ -1248,7 +1232,6 @@ Tag for the Insurance industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_manufacturing
 	a gist:IndustrySector ;
-	rdfs:label "Manufacturing"^^xsd:string ;
 	skos:altLabel "Manufacturing"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Manufacturing industry sector"""^^xsd:string ;
@@ -1258,7 +1241,6 @@ Tag for the Manufacturing industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_mining
 	a gist:IndustrySector ;
-	rdfs:label "Mining"^^xsd:string ;
 	skos:altLabel "Mining"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Mining industry sector"""^^xsd:string ;
@@ -1268,8 +1250,8 @@ Tag for the Mining industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_non-Profit
 	a gist:IndustrySector ;
-	rdfs:label "Non Profit"^^xsd:string ;
 	skos:altLabel
+		"Non Profit"^^xsd:string ,
 		"Non-Profit"^^xsd:string ,
 		"Nonprofit"^^xsd:string
 		;
@@ -1281,7 +1263,6 @@ Tag for the Non-Profit industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_pharmaceuticals
 	a gist:IndustrySector ;
-	rdfs:label "Pharmaceuticals"^^xsd:string ;
 	skos:altLabel "Pharmaceuticals"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Pharmaceuticals industry sector"""^^xsd:string ;
@@ -1291,7 +1272,6 @@ Tag for the Pharmaceuticals industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_retail
 	a gist:IndustrySector ;
-	rdfs:label "Retail"^^xsd:string ;
 	skos:altLabel "Retail"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Retail industry sector"""^^xsd:string ;
@@ -1301,7 +1281,6 @@ Tag for the Retail industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_technology
 	a gist:IndustrySector ;
-	rdfs:label "Technology"^^xsd:string ;
 	skos:altLabel "Technology"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Technology industry sector"""^^xsd:string ;
@@ -1311,7 +1290,6 @@ Tag for the Technology industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_telecommunications
 	a gist:IndustrySector ;
-	rdfs:label "Telecommunications"^^xsd:string ;
 	skos:altLabel "Telecommunications"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Telecommunications industry sector"""^^xsd:string ;
@@ -1321,7 +1299,6 @@ Tag for the Telecommunications industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_transportation
 	a gist:IndustrySector ;
-	rdfs:label "Transportation"^^xsd:string ;
 	skos:altLabel "Transportation"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Transportation industry sector"""^^xsd:string ;
@@ -1331,7 +1308,6 @@ Tag for the Transportation industry sector"""^^xsd:string ;
 
 gist:_IndustrySector_utilities
 	a gist:IndustrySector ;
-	rdfs:label "Utilities"^^xsd:string ;
 	skos:altLabel "Utilities"^^xsd:string ;
 	skos:definition """STIX 2.1 description:
 Tag for the Utilities industry sector"""^^xsd:string ;


### PR DESCRIPTION
Closes #94 
Closes #79  

Changes made to `rdfs:label` references:
- Removed if redundant to existing `skos:altLabel`
- Changed to `skos:altLabel` if literal is not already a `skos:altLabel`
- Changed to `skos:prefLabel` if only `rdfs:label` was used